### PR TITLE
feat: add platform-specific URL validation for LinkedIn and GitHub

### DIFF
--- a/resume-builder.html
+++ b/resume-builder.html
@@ -131,8 +131,11 @@
                                 <label for="location">Location</label>
                                 <input type="text" id="location">
 
-                                <label for="linkedin">LinkedIn / Portfolio URL</label>
+                                <label for="linkedin">LinkedIn URL</label>
                                 <input type="url" id="linkedin">
+
+                                <label for="github">GitHub URL</label>
+                                <input type="url" id="github">
 
                                 <h2 class="section-title">Professional Summary</h2>
                                 <textarea id="summary" rows="4"></textarea>
@@ -188,7 +191,8 @@
       <span id="preview-email"></span> |
       <span id="preview-phone"></span> |
       <span id="preview-location"></span><br>
-      <span id="preview-linkedin"></span>
+      <span id="preview-linkedin"></span> |
+      <span id="preview-github"></span>
     </div>
   </header>
 
@@ -283,10 +287,19 @@
 
                     if (fieldId === 'linkedin') {
                         const url = e.target.value.trim();
-                        if (url && !Validator.isValidURL(url)) {
-                            ValidationUI.showError('linkedin', 'Please enter a valid URL');
+                        if (url && !Validator.isValidLinkedIn(url)) {
+                            ValidationUI.showError('linkedin', 'Please enter a valid LinkedIn URL');
                         } else {
                             ValidationUI.clearError('linkedin');
+                        }
+                    }
+
+                    if (fieldId === 'github') {
+                        const url = e.target.value.trim();
+                        if (url && !Validator.isValidGitHub(url)) {
+                            ValidationUI.showError('github', 'Please enter a valid GitHub URL');
+                        } else {
+                            ValidationUI.clearError('github');
                         }
                     }
 
@@ -473,6 +486,7 @@
                 setText('preview-phone', byId('phone') ? byId('phone').value : '');
                 setText('preview-location', byId('location') ? byId('location').value : '');
                 setText('preview-linkedin', byId('linkedin') ? byId('linkedin').value : '');
+                setText('preview-github', byId('github') ? byId('github').value : '');
                 setText('preview-summary', byId('summary') ? byId('summary').value : '');
 
                 const degree = byId('degree') ? byId('degree').value : '';
@@ -506,6 +520,7 @@
                     phone: document.getElementById('phone') ? document.getElementById('phone').value : '',
                     location: document.getElementById('location') ? document.getElementById('location').value : '',
                     linkedin: document.getElementById('linkedin') ? document.getElementById('linkedin').value : '',
+                    github: document.getElementById('github') ? document.getElementById('github').value : '',
                     summary: document.getElementById('summary') ? document.getElementById('summary').value : '',
                     degree: document.getElementById('degree') ? document.getElementById('degree').value : '',
                     institution: document.getElementById('institution') ? document.getElementById('institution').value : '',
@@ -533,6 +548,7 @@
                     document.getElementById('phone').value = data.phone;
                     document.getElementById('location').value = data.location;
                     document.getElementById('linkedin').value = data.linkedin;
+                    document.getElementById('github').value = data.github || '';
                     document.getElementById('summary').value = data.summary;
                     document.getElementById('degree').value = data.degree;
                     document.getElementById('institution').value = data.institution;

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -21,6 +21,15 @@ const Validator = {
     return phoneRegex.test(phone) && phone.replace(/\D/g, '').length >= 7;
   },
 
+  isValidLinkedIn: (url) => {
+    const regex = /^https:\/\/(www\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+\/?$/;
+    return typeof url === 'string' && regex.test(url);
+  },
+  isValidGitHub: (url) => {
+    const regex = /^https:\/\/(www\.)?github\.com\/[a-zA-Z0-9_-]+\/?$/;
+    return typeof url === 'string' && regex.test(url);
+  },
+
   isValidURL: (url) => {
     if (typeof url !== 'string') {
       return false;
@@ -97,6 +106,32 @@ describe('Validator', () => {
       expect(Validator.isValidPhone(null)).toBe(false);
       expect(Validator.isValidPhone(undefined)).toBe(false);
       expect(Validator.isValidPhone(1234567890)).toBe(false);
+    });
+  });
+
+  describe('isValidLinkedIn', () => {
+    test('should return true for valid LinkedIn URLs', () => {
+      expect(Validator.isValidLinkedIn('https://www.linkedin.com/in/john-doe')).toBe(true);
+      expect(Validator.isValidLinkedIn('https://linkedin.com/in/johndoe123/')).toBe(true);
+    });
+
+    test('should return false for non-LinkedIn or malformed URLs', () => {
+      expect(Validator.isValidLinkedIn('https://github.com/johndoe')).toBe(false);
+      expect(Validator.isValidLinkedIn('linkedin.com/in/johndoe')).toBe(false);
+      expect(Validator.isValidLinkedIn('https://www.linkedin.com/feed/')).toBe(false);
+    });
+  });
+
+  describe('isValidGitHub', () => {
+    test('should return true for valid GitHub URLs', () => {
+      expect(Validator.isValidGitHub('https://github.com/johndoe')).toBe(true);
+      expect(Validator.isValidGitHub('https://www.github.com/john_doe/')).toBe(true);
+    });
+
+    test('should return false for non-GitHub or malformed URLs', () => {
+      expect(Validator.isValidGitHub('https://linkedin.com/in/johndoe')).toBe(false);
+      expect(Validator.isValidGitHub('github.com/johndoe')).toBe(false);
+      expect(Validator.isValidGitHub('https://github.com/')).toBe(false);
     });
   });
 

--- a/validation.js
+++ b/validation.js
@@ -24,6 +24,27 @@ const Validator = {
     const phoneRegex = /^[+]?[(]?[0-9]{1,4}[)]?[-\s.]?[(]?[0-9]{1,4}[)]?[-\s.]?[0-9]{1,9}$/;
     return phoneRegex.test(phone);
   },
+
+  /**
+   * Validates LinkedIn profile URL
+   * @param {string} url - LinkedIn URL to validate
+   * @returns {boolean} - True if valid, false otherwise
+   */
+  isValidLinkedIn(url) {
+    const linkedinRegex = /^https:\/\/(www\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+\/?$/;
+    return linkedinRegex.test(url);
+  },
+
+  /**
+   * Validates GitHub profile URL
+   * @param {string} url - GitHub URL to validate
+   * @returns {boolean} - True if valid, false otherwise
+   */
+  isValidGitHub(url) {
+    const githubRegex = /^https:\/\/(www\.)?github\.com\/[a-zA-Z0-9_-]+\/?$/;
+    return githubRegex.test(url);
+  },
+
   isValidURL(url) {
     if (!url) {
       return false;


### PR DESCRIPTION
## Description

This PR introduces platform-specific regex validation for LinkedIn and GitHub profile URLs. Previously, the application used generic URL validation which allowed broken or irrelevant links to be included in the generated resume. These changes ensure that users provide valid professional profile links, improving the quality of the final output.

Closes #97


### Type of Change
-[x] ✨ New feature (non-breaking change that adds functionality)

[x] 🧪 Test addition/modification


##Changes Made
validation.js: Added isValidLinkedIn and isValidGitHub methods using specific regex patterns.

resume-builder.html:

Added a new input field for GitHub URLs.

Updated the real-time input event listener to apply platform-specific validation.

Updated updatePreview and saveResumeData to handle the GitHub field.

tests/validation.test.js: Added unit tests for the new validation functions, covering valid/invalid formats and various protocols.

Testing
Test Coverage
[x] Added/updated unit tests

[x] Tested locally

[x] All tests pass (npm test)

## Related Issues

Closes #97
